### PR TITLE
Add Windows/Linux cross-platform menu icon support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,12 +85,16 @@ add_qtc_plugin(Qt_MCP_Plugin
     mcp.qrc
 )
 
-# Add macOS-specific Objective-C++ source for native menu icons
+# Add platform-specific menu icon implementation
 if(APPLE)
     target_sources(Qt_MCP_Plugin PRIVATE macos_menu_icon.mm)
     # Link against AppKit framework for NSMenu/NSMenuItem access
     target_link_libraries(Qt_MCP_Plugin PRIVATE "-framework AppKit")
+else()
+    # Windows/Linux: Use stub implementation
+    target_sources(Qt_MCP_Plugin PRIVATE platform_menu_icon.cpp)
 endif()
+
 
 # Set plugin properties without version in filename
 set_target_properties(Qt_MCP_Plugin PROPERTIES

--- a/README.md
+++ b/README.md
@@ -50,6 +50,28 @@ After a successful build, restart Cursor to enable AI control of Qt Creator.
 
 **For AI Assistants:** See `.cursorrules` for detailed build instructions and troubleshooting.
 
+## Architecture
+
+### Cross-Platform Menu Icons
+
+The plugin displays an icon in the **Tools → MCP Plugin** menu. Menu icon handling is platform-specific:
+
+- **macOS**: Uses native AppKit APIs (`macos_menu_icon.mm`) to force icon display, as Qt may hide menu icons per Apple HIG
+- **Windows/Linux**: Uses Qt's native icon support via stub implementation (`platform_menu_icon.cpp`)
+
+### Source Files
+
+| File | Purpose |
+|------|---------|
+| `qt_mcp_plugin.cpp` | Main plugin entry point, menu setup |
+| `mcpserver.cpp/h` | HTTP server on port 3001 |
+| `mcpcommands.cpp/h` | MCP tool implementations |
+| `macos_menu_icon.mm/h` | macOS native menu icon support |
+| `platform_menu_icon.cpp` | Windows/Linux menu icon stub |
+| `issuesmanager.cpp/h` | Build issues tracking |
+| `httpparser.cpp/h` | HTTP request parsing |
+| `httpresponse.cpp/h` | HTTP response generation |
+
 ## Extending the Plugin
 
 **Let AI do the work:** The plugin is designed for AI-assisted development. Simply describe what you want to add and let your AI assistant:

--- a/platform_menu_icon.cpp
+++ b/platform_menu_icon.cpp
@@ -1,0 +1,21 @@
+/**
+ * Cross-Platform Menu Icon Support - Non-macOS Implementation
+ * 
+ * On Windows/Linux: Qt handles menu icons natively, so this provides stub implementations.
+ * On macOS: The macos_menu_icon.mm file provides the actual implementation.
+ */
+
+#include "macos_menu_icon.h"
+
+#ifndef Q_OS_MACOS
+
+// Stub implementations for Windows/Linux - Qt handles icons natively
+void setMenuIconWithFallback(QMenu *menu, const QIcon &icon, const QString &menuTitle)
+{
+    Q_UNUSED(menu);
+    Q_UNUSED(icon);
+    Q_UNUSED(menuTitle);
+    // No-op: Qt's native icon support works on these platforms
+}
+
+#endif


### PR DESCRIPTION
## Summary

- Add \platform_menu_icon.cpp\ with stub implementation for non-macOS platforms
- Update \CMakeLists.txt\ to conditionally compile platform-specific sources:
  - macOS: \macos_menu_icon.mm\ (native AppKit)
  - Windows/Linux: \platform_menu_icon.cpp\ (Qt native)
- Update \README.md\ with architecture section documenting source files

## Problem

Windows builds were failing with linker error:
\\\
error LNK2019: unresolved external symbol setMenuIconWithFallback
\\\

The \setMenuIconWithFallback\ function was only implemented in the macOS-specific \macos_menu_icon.mm\ file, which is not compiled on Windows/Linux.

## Solution

Added \platform_menu_icon.cpp\ which provides a stub implementation for Windows/Linux where Qt handles menu icons natively. The CMakeLists.txt now conditionally includes the appropriate source file based on platform.

## Testing

- [x] Builds successfully on Windows
- [x] Plugin loads and MCP server responds on port 3001
- [x] Version verified: 1.31.108

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds cross-platform handling for the plugin’s menu icon with platform-conditional builds and documentation updates.
> 
> - Introduces `platform_menu_icon.cpp` providing a no-op stub for Windows/Linux while macOS keeps native implementation in `macos_menu_icon.mm`
> - Updates `CMakeLists.txt` to conditionally compile `macos_menu_icon.mm` on macOS (linking `AppKit`) and `platform_menu_icon.cpp` elsewhere
> - Expands `README.md` with an Architecture section detailing menu icon handling and a source file overview
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82d254103f765ad343b2016cb36afd70eabc44d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->